### PR TITLE
Dockerfile improvements and move to alpine:edge

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,14 +34,13 @@ RUN apk add --no-cache dbus alsa-lib libdaemon popt openssl soxr avahi libconfig
         --with-metadata \
   && make \
   && make install \
-  && apk del --purge .build-deps \
   #
   # Build and Install librespot (Spotify Client)
   # - Disable all audio out plugins, as they are not needed.
   && cd /app/build \
-  && git clone https://github.com/librespot-org/librespot librespot \
+  && git clone https://github.com/librespot-org/librespot librespot.git \
   && cd librespot.git \
-  && apk add --no-cache --upgrade --virtual .build-deps-librespot libconfig-dev cargo build-essential \
+  && apk add --no-cache --upgrade --virtual .build-deps-librespot libconfig-dev cargo build-base \
   && cargo build --release --no-default-features \
   && cp ./target/release/librespot /usr/sbin/ \
   && chmod +x /usr/sbin/librespot \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,22 @@
-FROM alpine:latest
+FROM alpine:edge AS snapcast
 
-# Add edge and testing as tagged repositories to APK (will only be used when tag is explicitly named)
-RUN echo -e "@edge https://dl-cdn.alpinelinux.org/alpine/edge/main\n@edgecommunity https://dl-cdn.alpinelinux.org/alpine/edge/community\n@testing https://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories \
-  && apk update
+# Install snapcast
+# Note: Do not install snapcast-server (does not include webdir, ...), install snapcast instead
+RUN apk add --no-cache --upgrade snapcast
+
+ENTRYPOINT [ "/usr/bin/snapserver" ]
+
+
+###
+FROM snapcast AS snapcast-extended
 
 # Install shairport-sync Runtime dependencies
-RUN apk add --no-cache dbus alsa-lib libdaemon popt libressl soxr avahi libconfig 
-
-# Note: Build shairport-sync with metadata, stdout and pipe support (apk repo is without)
-#   APK way: `RUN apk add shairport-sync --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing`
-RUN apk add --no-cache git build-base autoconf automake libtool alsa-lib-dev libdaemon-dev popt-dev libressl-dev soxr-dev avahi-dev libconfig-dev \
-  && mkdir -p /srv/build \
-  && cd /srv/build \
+RUN apk add --no-cache dbus alsa-lib libdaemon popt openssl soxr avahi libconfig \
+  #
+  # Note: Build shairport-sync with metadata, stdout and pipe support (apk repo is without)
+  && apk add --no-cache --upgrade --virtual .build-deps git build-base autoconf automake libtool alsa-lib-dev libdaemon-dev popt-dev libressl-dev soxr-dev avahi-dev libconfig-dev \
+  && mkdir -p /app/build \
+  && cd /app/build \
   && git clone https://github.com/mikebrady/shairport-sync.git shairport-sync \
   && cd shairport-sync \
   && autoreconf -i -f \
@@ -25,46 +30,35 @@ RUN apk add --no-cache git build-base autoconf automake libtool alsa-lib-dev lib
         --with-metadata \
   && make \
   && make install \
-  && cd / \
-  && apk del --purge git build-base autoconf automake libtool alsa-lib-dev libdaemon-dev popt-dev libressl-dev soxr-dev avahi-dev libconfig-dev
-
-
-# Install snapcast
-# Note: Do not install snapcast-server (does not include webdir, ...), install snapcast instead
-# FixMe: Added libstdc++ from edge to meet newest snapcast dependencies. Can be removed, if main libstdc++ is updated (10.3.1_git20211027-r0 -> 11.2.1_git20211128-r3) [2021-12-28]
-RUN apk add --no-cache libstdc++@edge snapcast@edgecommunity
-
-# Install librespot (Spotify Client)
-RUN apk add --no-cache libconfig-dev alsa-lib-dev cargo \
+  && apk del --purge .build-deps \
+  && rm -rf /app/build \
+  #
+  # Install librespot (Spotify Client)
+  && apk add --no-cache --upgrade --virtual .build-deps libconfig-dev alsa-lib-dev cargo \
   && cargo install librespot \
-  && apk del --purge libconfig-dev alsa-lib-dev cargo
+  && apk del --purge .build-deps \
+  #
+  # Install NGINX for SSL reverse proxy to webinterface
+  && apk add --no-cache --upgrade nginx
+
 
 # Install NGINX for SSL reverse proxy to webinterface
-RUN mkdir -p /run/nginx/ /srv/certs/ \
-  && apk add --no-cache nginx openssl
+RUN mkdir -p /run/nginx/ /app/certs/
 COPY nginx.conf/default.conf /etc/nginx/http.d/default.conf
-VOLUME /srv/certs
+VOLUME /app/certs
 
-# Cleanup
-RUN rm -rf \
-  /srv/build \
-  /var/cache/apk/*
+
 
 # Copy startup script
 COPY start.sh /start.sh
 RUN chmod +x /start.sh
 
-
 # Expose Ports
-## Snapcast Ports
-EXPOSE 1704-1705 1780
-## AirPlay ports
-EXPOSE 3689/tcp 5000-5005/tcp 6000-6005/udp
-## Avahi ports
-EXPOSE 5353
-## NGINX ports
-EXPOSE 443 
-
+## Snapcast Ports: 1704-1705 1780
+## AirPlay ports:  3689/tcp 5000-5005/tcp 6000-6005/udp
+## Avahi ports:    5353
+## NGINX ports:    443
+EXPOSE 1704-1705 1780 3689 5000-5005 6000-6005/udp 5353 443
 
 # Run start script
 ENV PATH "/root/.cargo/bin:$PATH"

--- a/Dockerfile
+++ b/Dockerfile
@@ -72,5 +72,5 @@ RUN chmod +x /app/start.sh
 EXPOSE 1704-1705 1780 3689 5000-5005 6000-6005/udp 5353 443
 
 # Run start script
-ENV PATH "/root/.cargo/bin:$PATH"
-CMD ["/app/start.sh"]
+ENTRYPOINT [ "/bin/sh", "-c" ]
+CMD [ "/app/start.sh" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,8 +50,9 @@ VOLUME /app/certs
 
 
 # Copy startup script
-COPY start.sh /start.sh
-RUN chmod +x /start.sh
+WORKDIR /app
+COPY start.sh /app/start.sh
+RUN chmod +x /app/start.sh
 
 # Expose Ports
 ## Snapcast Ports: 1704-1705 1780
@@ -62,4 +63,4 @@ EXPOSE 1704-1705 1780 3689 5000-5005 6000-6005/udp 5353 443
 
 # Run start script
 ENV PATH "/root/.cargo/bin:$PATH"
-CMD ["./start.sh"]
+CMD ["/app/start.sh"]

--- a/README.md
+++ b/README.md
@@ -35,11 +35,11 @@ docker run -it \
 
 Optional volume mounts for NGINX reverse proxy:
 ```bash
-  -v '~/nginx_certs/:/srv/certs/'
+  -v '~/nginx_certs/:/app/certs/'
 ```
 
 ## Configuration File Paths
 - `/root/.config/snapserver/`  
   Path to snapcast server configuration. Place your custom `snapserver.conf` file here. Snapserver will also place its run-time configuration (like `server.json`) here.
-- `/srv/certs/`  
+- `/app/certs/`  
   NGINX is configured as a reverse proxy and will listen on port 443 to serve a HTTPS-secured connection to Snapweb. This folder must contain the TLS certificate files: `snapserver.pem` contains the certificate (chain) and `snapserver.key` the private key file.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,7 +3,7 @@ version: '3'
 services:
   snapserver:
     image: 'firefrei/snapcast:latest'
-    restart: 'unless-stopped'
+    restart: always
     ports:
       # Snapcast Ports
       - '1704-1705:1704-1705'
@@ -21,4 +21,4 @@ services:
       - ./config_snapcast/:/root/.config/snapserver/
 
       # Optional: HTTPS certificates for NGINX
-      #- ./nginx_certs/:/srv/certs/
+      #- ./nginx_certs/:/app/certs/

--- a/nginx.conf/default.conf
+++ b/nginx.conf/default.conf
@@ -4,8 +4,8 @@ server {
 
     root    html;
 
-    ssl_certificate /srv/certs/snapserver.pem;
-    ssl_certificate_key /srv/certs/snapserver.key;
+    ssl_certificate /app/certs/snapserver.pem;
+    ssl_certificate_key /app/certs/snapserver.key;
     ssl_protocols TLSv1.3 TLSv1.2 TLSv1.1;
 
     location / {

--- a/start.sh
+++ b/start.sh
@@ -10,12 +10,12 @@ dbus-daemon --system
 avahi-daemon  --daemonize --no-chroot
 
 # NGINX: generate self-signed ssl certificates, if no certs are existant
-if [ -s /srv/certs/snapserver.pem ] || [ -s /srv/certs/snapserver.key ] || [ -n "${SKIP_CERTS_GENERATE}" ]; then
+if [ -s /app/certs/snapserver.pem ] || [ -s /app/certs/snapserver.key ] || [ -n "${SKIP_CERTS_GENERATE}" ]; then
     echo "Server SSL certificates for NGINX already exist, skipping generation."
 else
     echo "Generating self-signed certificates for NGINX."
     openssl req -x509 -nodes -days 365 -newkey rsa:2048 \
-        -keyout /srv/certs/snapserver.key -out /srv/certs/snapserver.pem \
+        -keyout /app/certs/snapserver.key -out /app/certs/snapserver.pem \
         -subj "/C=DE/ST=Bavaria/L=Nuremberg/O=Snapserver/CN=snapserver"
 fi
 


### PR DESCRIPTION
- Use `alpine:edge` as the base image
- Build librespot from source (without audio out plugins)
- Optimize Dockerfile
- Change working directory from `/srv` to `/app`

## Breaking Changes
Volume mounts going to `/srv` need to be changed to `/app`.