### PR TITLE
feat: add args for snapcast user id & group id to dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,12 @@
 FROM alpine:edge AS snapcast
 
+ARG UID=1000
+ARG GID=1000
+
+# manually add user to map ids to host's file system
+RUN addgroup -g "${GID}" -S snapcast
+RUN adduser -u "${UID}" -D -G snapcast -h '/var/lib/snapserver' -H snapcast
+
 # Install snapcast-server and snapweb
 RUN apk add --no-cache --upgrade snapcast-server \
   # Install latest release of snapweb 


### PR DESCRIPTION
Hi Matthias,

thank you for your awesome work on the docker snapcast images.
I had issues integrating your container in my dietpi / portainer / compose setup. I was not able to set disk permissions due to inconsistant user IDs. As far as i know, the easiest way out is to make user id and group id configurable during docker build. Seems to be a standard solution, so maybe you want to integrate this into your code to share with others.
  