### PR TITLE
fix: :bug: Replace ports in nginx config using regex, to achieve idempotency

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -87,7 +87,6 @@ if [ "${NGINX_ENABLED}" -eq 1 ]; then
     sed -E -i "s/([[:blank:]]+)(listen[[:blank:]]*)(\[::\]:)(\d\d*)/    listen [::]:${NGINX_HTTPS_PORT}/g" /tmp/default.conf
     cat /tmp/default.conf > /etc/nginx/http.d/default.conf
     rm /tmp/default.conf
-    /usr/sbin/nginx -t
 
     # NGINX: Create supervisord configuration
     NGINX_SUPERVISORD_CONFIG="

--- a/setup.sh
+++ b/setup.sh
@@ -84,7 +84,7 @@ if [ "${NGINX_ENABLED}" -eq 1 ]; then
     # Note: sed cannot directly replace in-file as it cannot create a temporary file under this directory.
    
     sed -E "s/([[:blank:]]+)(listen[[:blank:]]*)(\d\d*)/    listen ${NGINX_HTTPS_PORT}/g" /etc/nginx/http.d/default.conf > /tmp/default.conf
-    sed -E -i "s/([[:blank:]]+)(listen[[:blank:]]*)(\[::\]:)(\d\d*)/    listen [::]: ${NGINX_HTTPS_PORT}/g" /tmp/default.conf
+    sed -E -i "s/([[:blank:]]+)(listen[[:blank:]]*)(\[::\]:)(\d\d*)/    listen [::]:${NGINX_HTTPS_PORT}/g" /tmp/default.conf
     cat /tmp/default.conf > /etc/nginx/http.d/default.conf
     rm /tmp/default.conf
 

--- a/setup.sh
+++ b/setup.sh
@@ -87,6 +87,7 @@ if [ "${NGINX_ENABLED}" -eq 1 ]; then
     sed -E -i "s/([[:blank:]]+)(listen[[:blank:]]*)(\[::\]:)(\d\d*)/    listen [::]:${NGINX_HTTPS_PORT}/g" /tmp/default.conf
     cat /tmp/default.conf > /etc/nginx/http.d/default.conf
     rm /tmp/default.conf
+    /usr/sbin/nginx -t
 
     # NGINX: Create supervisord configuration
     NGINX_SUPERVISORD_CONFIG="

--- a/setup.sh
+++ b/setup.sh
@@ -82,7 +82,9 @@ if [ "${NGINX_ENABLED}" -eq 1 ]; then
 
     # NGINX: Replace port in NGINX config
     # Note: sed cannot directly replace in-file as it cannot create a temporary file under this directory.
-    sed "s/443/${NGINX_HTTPS_PORT}/g" /etc/nginx/http.d/default.conf > /tmp/default.conf
+   
+    sed -E "s/([[:blank:]]+)(listen[[:blank:]]*)(\d\d*)/    listen ${NGINX_HTTPS_PORT}/g" /etc/nginx/http.d/default.conf > /tmp/default.conf
+    sed -E -i "s/([[:blank:]]+)(listen[[:blank:]]*)(\[::\]:)(\d\d*)/    listen [::]: ${NGINX_HTTPS_PORT}/g" /tmp/default.conf
     cat /tmp/default.conf > /etc/nginx/http.d/default.conf
     rm /tmp/default.conf
 


### PR DESCRIPTION

Hi Matthias,

thank you for your awesome work on the docker snapcast images.
Each container startup tried to replace a "443" string in nginx config. This lead to two more '4' digits each time the container started. With regex, sed is able to replace all port digits by the given port number.
Had to add a rather stupid regex and separate sed invocations for ip4 & ip6 as capture groups didn't work.