### PR TITLE
Add libmdns feature on librespot compilation following breaking change on 0.6.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -82,7 +82,7 @@ RUN mkdir -p /app/build \
   && apk add --no-cache --upgrade --virtual .build-deps git libconfig-dev cargo build-base cmake rust-bindgen clang18-dev \
   && git clone https://github.com/librespot-org/librespot.git librespot.git \
   && cd librespot.git \
-  && cargo build --release --no-default-features \
+  && cargo build --release --no-default-features --features with-libmdns\
   && cp ./target/release/librespot /usr/sbin/ \
   && chmod +x /usr/sbin/librespot \
   #

--- a/Dockerfile
+++ b/Dockerfile
@@ -80,9 +80,9 @@ FROM snapcast-airport AS snapcast-airport-spotify
 RUN mkdir -p /app/build \
   && cd /app/build \
   && apk add --no-cache --upgrade --virtual .build-deps git libconfig-dev cargo build-base cmake rust-bindgen clang18-dev \
-  && git clone https://github.com/librespot-org/librespot.git librespot.git \
+  && git clone https://github.com/librespot-org/librespot.git -b master librespot.git \
   && cd librespot.git \
-  && cargo build --release --no-default-features --features with-libmdns\
+  && cargo build --release --no-default-features --features with-libmdns \
   && cp ./target/release/librespot /usr/sbin/ \
   && chmod +x /usr/sbin/librespot \
   #


### PR DESCRIPTION
Hello @firefrei,

On version 0.6.0, librespot enabled support for multiple discovery backends ([changelog](https://github.com/librespot-org/librespot/releases/tag/v0.6.0)):

> [discovery] librespot can now be compiled with multiple MDNS/DNS-SD backends (avahi, dns_sd, libmdns) which can be selected using a CLI flag. The defaults are unchanged (breaking).

When compiling with the `--no-default-features` flag as it's done in this repo, none of the backend is added to the binary, making the discovery feature unavailable. This makes librespot unusable when not using spotify credentials.

I added the libmdns feature to the compilation option which was the default backend on v0.5.0 to restore the discovery feature.
I also changed the branch used to clone librespot from dev to master. This change is not required but I think it should make the container more stable.
